### PR TITLE
Mac M1 ksh update

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ ark select chain stargaze # reads juno.env file
 echo $WALLET_MINTER # test correct wallet is shown as defined in env file
 ```
 
+### NOTE:
+if using Mac OS X version after Catalina (re: Zsh replaced Bash as macOS's default terminal shell in macOS Catalina)
+switch to bash before setting up/sourcing CLI.
+```
+/bin/bash
+```
+
+
 ## Create a collection
 
 ```sh

--- a/cli/ark-cli.sh
+++ b/cli/ark-cli.sh
@@ -43,6 +43,8 @@ source "$ARK_CLI_DIR"/chain-query-height.sh
 source "$ARK_CLI_DIR"/nft-query-snapshot.sh
 source "$ARK_CLI_DIR"/wasm_tx_store.sh
 
+ARCH="$(uname -m)"
+
 function ark() {
     ARGS=$@ # backup args
 
@@ -165,7 +167,11 @@ function ark() {
                     fi
                     ;;
                 select)
-                    CHAIN=${1,,} # lowercase
+                    if [[ ARCH="arm64" ]]; then
+                        CHAIN=${1:l} # lowercase
+                    else
+                        CHAIN=${1,,} # lowercase
+                    fi
                     ARK_ENV_FILE="$ARK_ENV_DIR/"${CHAIN}.env
                     echo "reading $ARK_ENV_FILE" >&2
                     source "$ARK_ENV_FILE"


### PR DESCRIPTION
Current code fails on Mac M1 (Monterey version 12.7.3)
readme update fixes - `ark:122: bad substitution`
code update fixes - `ark:122: bad substitution`